### PR TITLE
Fixes issue with adding services and proxies

### DIFF
--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -80,29 +80,29 @@ services:
   mqtt:
     image: eclipse-mosquitto
     container_name: mqtt
-    ports:
-      - "1883:1883"
+    expose:
+      - "1883"
     <<: *protocol
 
   http:
     image: httpd
     container_name: http
-    ports:
-      - "80:80"
+    expose:
+      - "80"
     <<: *protocol
 
   modbus:
     image: oitc/modbus-server
     container_name: modbus
-    ports:
-      - "502:502"
+    expose:
+      - "502"
     <<: *protocol
 
   ocpp:
     image: ldonini/ocpp1.6-central-system # v1.6
     container_name: ocpp
-    ports:
-      - "443:443"
+    expose:
+      - "443"
     <<: *protocol
 
 networks:

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -36,7 +36,6 @@ type ProxyManager interface {
 
 // Simple implementation of the proxy manager
 // This manager has access to the proxy endpoints registered. However, it does not observe newly
-//
 type ProxyManagerItem struct {
 	ProxyManager
 
@@ -49,12 +48,6 @@ type ProxyManagerItem struct {
 
 // Create a new proxy and add it to the manager
 func (pm *ProxyManagerItem) CreateProxy(network globals.Network, port int) (pe Proxy, err error) {
-
-	// Check if there is another proxy with the same port
-	if proxy, _ := pm.GetProxyFromParams(network, port); proxy != nil {
-		err = fmt.Errorf("proxy already registered")
-		return
-	}
 
 	// Create the proxy
 	pe, err = NewProxyEndpoint(port, network)
@@ -133,35 +126,6 @@ func (pm *ProxyManagerItem) DeleteProxy(id string) (err error) {
 
 func (pm *ProxyManagerItem) GetProxies() []Proxy {
 	return pm.proxies
-}
-
-// Returns a proxy by the port number
-func (pm *ProxyManagerItem) GetProxyFromParams(network globals.Network, port int) (pe Proxy, err error) {
-	// Iterate the proxies registered, and if the proxy using the given port is found, return it
-	for _, proxy := range pm.proxies {
-		if proxy.GetPort() == port && proxy.GetNetwork() == network {
-			pe = proxy
-			return
-		}
-	}
-
-	// If the proxy was not foun, send an error
-	err = fmt.Errorf("proxy not found")
-	return
-}
-
-// Set the service for some proxy
-func (pm *ProxyManagerItem) SetService(port int, service services.Service) (pe Proxy, err error) {
-	// Get the proxy from the list
-	pe, err = pm.GetProxyFromParams(service.GetNetwork(), port)
-	if err != nil {
-		return
-	}
-
-	// If the proxy was found, set the service
-	pe.SetService(service)
-
-	return
 }
 
 // Constructor for the proxy manager

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -88,24 +88,26 @@ func (se *ServiceManagerItem) AddServices(services ...Service) (serv []Service, 
 func (se *ServiceManagerItem) CreateService(name string, port int, network globals.Network, host string, interaction globals.Interaction) (s Service, err error) {
 	// Iterate the services to determine whether the
 	for _, service := range se.GetServices() {
-		// Validate the name
-		if service.GetName() == name {
-			err = fmt.Errorf("service name already taken")
+		// Validate the name and interaction
+		if service.GetName() == name && service.GetInteraction().String() == interaction.String() {
+			err = fmt.Errorf("service already included: %s (%s) - %s", name, interaction.String(), service.GetInteraction().String())
 			return
 		}
 
 		// Validate the address
 		if service.GetPort() == port && service.GetNetwork() == network && service.GetHost() == host {
-			err = fmt.Errorf("service address already taken")
+			err = fmt.Errorf("service address already taken: %s:%d", network.String(), port)
 			return
 		}
 	}
 
 	// Create the new service
 	s = NewService(name, port, network, host, interaction)
+	_, err = se.AddServices(s)
+	if err != nil {
+		return nil, err
+	}
 
-	// Append the new service to the list
-	se.services = append(se.services, s)
 	return
 }
 


### PR DESCRIPTION
* Solved issue with adding custom services with identical name but different interaction level. This was causing an issue with the low-level interaction honeypots, preventing new similar services to be instantiated.
* Solved a follow-up issue with creating proxies. Previously, there was a check for network (TCP/IP) and port instead of checking just the ID's.
* Removed some misleading functions
* Fixed the docker-compose file to instead opening ports, the internal services only accessible from the riotpot virtual network just "expose" (tell) in which ports do they listen for connections.