### PR TITLE
Changed template for high-level HTTP service

### DIFF
--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
     container_name: custom_http
     ports:
       - "80:80"
+      - "443:443"   # Expose port 443 for HTTPS
 
   modbus:
     image: oitc/modbus-server

--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -85,11 +85,11 @@ services:
     <<: *protocol
 
   http:
-    image: httpd
-    container_name: http
+    build:
+      context: ./service/custom_httpd   # Directory containing the custom Dockerfile and index.html
+    container_name: custom_http
     ports:
       - "80:80"
-    <<: *protocol
 
   modbus:
     image: oitc/modbus-server

--- a/build/docker/service/custom_httpd/Dockerfile
+++ b/build/docker/service/custom_httpd/Dockerfile
@@ -1,5 +1,21 @@
 # Use the official httpd image as the base image
 FROM httpd
 
-# Copy the "index.html" file to the document root
+# Copy the "index.html" file with "Hello, world!" content to the document root
 COPY index.html /usr/local/apache2/htdocs/
+
+# Copy the custom SSL certificate and key files
+COPY server.crt /usr/local/apache2/conf/server.crt
+COPY server.key /usr/local/apache2/conf/server.key
+
+# Enable SSL module and configure HTTPS
+RUN sed -i '/#LoadModule ssl_module/s/^#//g' /usr/local/apache2/conf/httpd.conf \
+    && echo "Listen 443" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "<VirtualHost *:443>" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  SSLEngine on" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  SSLCertificateFile /usr/local/apache2/conf/server.crt" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  SSLCertificateKeyFile /usr/local/apache2/conf/server.key" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  DocumentRoot /usr/local/apache2/htdocs" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  ErrorLog /dev/stderr" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  CustomLog /dev/stdout common" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "</VirtualHost>" >> /usr/local/apache2/conf/httpd.conf

--- a/build/docker/service/custom_httpd/Dockerfile
+++ b/build/docker/service/custom_httpd/Dockerfile
@@ -1,0 +1,5 @@
+# Use the official httpd image as the base image
+FROM httpd
+
+# Copy the "index.html" file to the document root
+COPY index.html /usr/local/apache2/htdocs/

--- a/build/docker/service/custom_httpd/README.md
+++ b/build/docker/service/custom_httpd/README.md
@@ -1,0 +1,22 @@
+# HTTPS Service Configuration
+
+To set up an HTTPS service using a custom Apache HTTP Server Docker image, you'll need to generate an SSL certificate (`server.crt`) and a private key (`server.key`). These files are necessary for enabling HTTPS encryption and securely serving your website.
+
+## Generating SSL Certificate and Private Key
+
+Follow these steps to generate a self-signed SSL certificate and private key:
+
+1. **Open a Terminal or Command Prompt**: You'll need access to a command-line interface to generate the SSL certificate and private key.
+
+2. **Navigate to the Directory**: Navigate to the directory where you want to store the SSL certificate and key files. If you're using the same directory as your `Dockerfile` and `docker-compose.yml`, there's no need to change directories.
+
+3. **Generate the Certificate and Key**: Use the OpenSSL command-line tool to generate the SSL certificate and private key.
+
+   ```
+   csharpCopy code
+   openssl req -x509 -newkey rsa:4096 -nodes -keyout server.key -out server.crt -days 365
+   ```
+
+   The above command generates a self-signed SSL certificate (`server.crt`) and a corresponding private key (`server.key`) with a validity of 365 days. It will prompt you to enter some details for the certificate (e.g., Country Name, State or Province Name, Common Name).
+
+4. **Protect the Private Key**: The `server.key` file contains sensitive information. Make sure to protect it and keep it secure. Avoid sharing it publicly or committing it to version control systems.

--- a/build/docker/service/custom_httpd/index.html
+++ b/build/docker/service/custom_httpd/index.html
@@ -1,0 +1,31 @@
+<html lang="en">
+	<head>
+		<!-- Page title -->
+		<title>SCADA Login</title>
+
+		<!-- Meta tags -->
+		<meta charset="UTF-8">
+		<meta id ="viewport" name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- CSS -->
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" 
+		rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" 
+		crossorigin="anonymous">
+	</head>
+	<body>
+		<h1>Login</h1><br>
+		<div class="container">
+			<form method="POST">
+				<div class="mb-3 row">
+					<label for="username" class="form-label">Username</label>
+					<input id="username" name="username" class="form-control" type="text" placeholder="Username">
+				</div>
+				<div class="mb-3 row">
+					<label for="password" class="form-label">Password</label>
+					<input id="password" name="password" class="form-control" type="password" placeholder="Password">
+				</div>
+				<button type="submit">Log In</button>
+			</form>
+		</div>
+	</body>
+	</html>

--- a/test/external/httpd_apache_test.go
+++ b/test/external/httpd_apache_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func removeWhitespace(s string) string {
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "\t", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
+func TestValidPathHandler(t *testing.T) {
+	resp, err := http.Get("http://localhost:80")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Check the response status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the response body
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	// Assert that the response body contains the expected HTML content
+	expectedBody := `<html lang="en">
+	<head>
+		<!-- Page title -->
+		<title>SCADA Login</title>
+
+		<!-- Meta tags -->
+		<meta charset="UTF-8">
+		<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- CSS -->
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" 
+		rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" 
+		crossorigin="anonymous">
+	</head>
+	<body>
+		<h1>Login</h1><br>
+		<div class="container">
+			<form method="POST">
+				<div class="mb-3 row">
+					<label for="username" class="form-label">Username</label>
+					<input id="username" name="username" class="form-control" type="text" placeholder="Username">
+				</div>
+				<div class="mb-3 row">
+					<label for="password" class="form-label">Password</label>
+					<input id="password" name="password" class="form-control" type="password" placeholder="Password">
+				</div>
+				<button type="submit">Log In</button>
+			</form>
+		</div>
+	</body>
+	</html>`
+
+	// Remove newline and tab characters from expectedBody and body
+	expectedBody = removeWhitespace(expectedBody)
+	bodyStr := removeWhitespace(string(body))
+	assert.Equal(t, expectedBody, bodyStr)
+}


### PR DESCRIPTION
Added a custom template for high-level HTTP service, so that it is not the default "It Works!" template.

Mimicking the HTTP page in low-level emulation:
![http_apache](https://github.com/honeynet/riotpot/assets/20755558/7f36367c-9324-4219-826b-7364816e4f56)

The dockerfile and index.html for configuration is under `/build/docker/service/custom_httpd`, also added the test file for high-level HTTP service (testing HTML content and status code):
```
~/Projects/riotpot/test/external$ go test httpd_apache_test.go 
ok      command-line-arguments  0.003s
```