### PR TITLE
High-level ssh service

### DIFF
--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
     container_name: custom_http
     ports:
       - "80:80"
+      - "443:443"   # Expose port 443 for HTTPS
 
   modbus:
     image: oitc/modbus-server

--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -85,11 +85,11 @@ services:
     <<: *protocol
 
   http:
-    image: httpd
-    container_name: http
+    build:
+      context: ./service/custom_httpd   # Directory containing the custom Dockerfile and index.html
+    container_name: custom_http
     ports:
       - "80:80"
-    <<: *protocol
 
   modbus:
     image: oitc/modbus-server

--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -112,6 +112,17 @@ services:
     networks:
       default:
 
+  ssh:
+    build:
+      context: ./service/custom_sshd
+      dockerfile: Dockerfile
+    container_name: ssh
+    restart: always
+    ports:
+      - "2222:22"  # Map port 2222 for SSH
+    networks:
+      default:
+
   telnet:
     build:
       context: ./service/custom_telnet

--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -112,6 +112,17 @@ services:
     networks:
       default:
 
+  telnet:
+    build:
+      context: ./service/custom_telnet
+      dockerfile: Dockerfile
+    container_name: telnet
+    restart: always
+    ports:
+      - "23:23"  # Map port 23 for Telnet
+    networks:
+      default:
+
   modbus:
     image: oitc/modbus-server
     container_name: modbus

--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -119,7 +119,7 @@ services:
     container_name: ssh
     restart: always
     ports:
-      - "2222:22"  # Map port 2222 for SSH
+      - "22:22"  # Map port 2222 for SSH
     networks:
       default:
 

--- a/build/docker/docker-compose.yaml
+++ b/build/docker/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
   ##########################################
   # Use the profile `protocol` to mount the image but do not start it
   # riotpot will deetermine which containers to start at a later time
-    
+
   mqtt:
     image: eclipse-mosquitto
     container_name: mqtt
@@ -87,10 +87,30 @@ services:
   http:
     build:
       context: ./service/custom_httpd   # Directory containing the custom Dockerfile and index.html
-    container_name: custom_http
+    container_name: http
     ports:
       - "80:80"
       - "443:443"   # Expose port 443 for HTTPS
+
+
+  ftp:
+    build:
+      context: ./service/custom_ftpd
+      dockerfile: Dockerfile
+    container_name: ftp
+    restart: always
+    ports:
+      - "21:21"                    # Map port 21 for FTP control
+      - "21000-21010:21000-21010"  # Map ports for passive mode data transfer
+    environment:
+      - USERS=ftpuser|password     # Set the default FTP user (you can add more users here)
+      # Passive mode ports range
+      - MIN_PORT=21000
+      - MAX_PORT=21010
+    volumes:
+      - ./ftp_data:/ftp/ftpuser:Z       # Map the FTP data directory
+    networks:
+      default:
 
   modbus:
     image: oitc/modbus-server

--- a/build/docker/service/custom_ftpd/Dockerfile
+++ b/build/docker/service/custom_ftpd/Dockerfile
@@ -1,0 +1,11 @@
+FROM delfer/alpine-ftp-server
+
+# Add your custom user credentials here (replace username|password with your desired values)
+ENV USERS="ftpuser|password"
+
+# Create directory for FTP user
+RUN mkdir -p ./ftp_data
+
+# Uncomment the following lines to set the passive mode ports range (optional)
+ENV MIN_PORT=21000
+ENV MAX_PORT=21010

--- a/build/docker/service/custom_httpd/Dockerfile
+++ b/build/docker/service/custom_httpd/Dockerfile
@@ -1,5 +1,21 @@
 # Use the official httpd image as the base image
 FROM httpd
 
-# Copy the "index.html" file to the document root
+# Copy the "index.html" file with "Hello, world!" content to the document root
 COPY index.html /usr/local/apache2/htdocs/
+
+# Copy the custom SSL certificate and key files
+COPY server.crt /usr/local/apache2/conf/server.crt
+COPY server.key /usr/local/apache2/conf/server.key
+
+# Enable SSL module and configure HTTPS
+RUN sed -i '/#LoadModule ssl_module/s/^#//g' /usr/local/apache2/conf/httpd.conf \
+    && echo "Listen 443" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "<VirtualHost *:443>" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  SSLEngine on" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  SSLCertificateFile /usr/local/apache2/conf/server.crt" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  SSLCertificateKeyFile /usr/local/apache2/conf/server.key" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  DocumentRoot /usr/local/apache2/htdocs" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  ErrorLog /dev/stderr" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "  CustomLog /dev/stdout common" >> /usr/local/apache2/conf/httpd.conf \
+    && echo "</VirtualHost>" >> /usr/local/apache2/conf/httpd.conf

--- a/build/docker/service/custom_httpd/Dockerfile
+++ b/build/docker/service/custom_httpd/Dockerfile
@@ -1,0 +1,5 @@
+# Use the official httpd image as the base image
+FROM httpd
+
+# Copy the "index.html" file to the document root
+COPY index.html /usr/local/apache2/htdocs/

--- a/build/docker/service/custom_httpd/README.md
+++ b/build/docker/service/custom_httpd/README.md
@@ -1,0 +1,22 @@
+# HTTPS Service Configuration
+
+To set up an HTTPS service using a custom Apache HTTP Server Docker image, you'll need to generate an SSL certificate (`server.crt`) and a private key (`server.key`). These files are necessary for enabling HTTPS encryption and securely serving your website.
+
+## Generating SSL Certificate and Private Key
+
+Follow these steps to generate a self-signed SSL certificate and private key:
+
+1. **Open a Terminal or Command Prompt**: You'll need access to a command-line interface to generate the SSL certificate and private key.
+
+2. **Navigate to the Directory**: Navigate to the directory where you want to store the SSL certificate and key files. If you're using the same directory as your `Dockerfile` and `docker-compose.yml`, there's no need to change directories.
+
+3. **Generate the Certificate and Key**: Use the OpenSSL command-line tool to generate the SSL certificate and private key.
+
+   ```
+   csharpCopy code
+   openssl req -x509 -newkey rsa:4096 -nodes -keyout server.key -out server.crt -days 365
+   ```
+
+   The above command generates a self-signed SSL certificate (`server.crt`) and a corresponding private key (`server.key`) with a validity of 365 days. It will prompt you to enter some details for the certificate (e.g., Country Name, State or Province Name, Common Name).
+
+4. **Protect the Private Key**: The `server.key` file contains sensitive information. Make sure to protect it and keep it secure. Avoid sharing it publicly or committing it to version control systems.

--- a/build/docker/service/custom_httpd/index.html
+++ b/build/docker/service/custom_httpd/index.html
@@ -1,0 +1,31 @@
+<html lang="en">
+	<head>
+		<!-- Page title -->
+		<title>SCADA Login</title>
+
+		<!-- Meta tags -->
+		<meta charset="UTF-8">
+		<meta id ="viewport" name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- CSS -->
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" 
+		rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" 
+		crossorigin="anonymous">
+	</head>
+	<body>
+		<h1>Login</h1><br>
+		<div class="container">
+			<form method="POST">
+				<div class="mb-3 row">
+					<label for="username" class="form-label">Username</label>
+					<input id="username" name="username" class="form-control" type="text" placeholder="Username">
+				</div>
+				<div class="mb-3 row">
+					<label for="password" class="form-label">Password</label>
+					<input id="password" name="password" class="form-control" type="password" placeholder="Password">
+				</div>
+				<button type="submit">Log In</button>
+			</form>
+		</div>
+	</body>
+	</html>

--- a/build/docker/service/custom_sshd/Dockerfile
+++ b/build/docker/service/custom_sshd/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu
+
+# Install OpenSSH
+RUN apt-get update && apt-get install -y openssh-server
+
+# Install OpenSSH server
+RUN apt-get update && apt-get install -y openssh-server
+
+# Copy the SSH public key to the container's root directory
+# COPY $SSH_KEY_PUB_PATH /root/.ssh/authorized_keys
+RUN mkdir -p /root/.ssh
+#RUN echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPp/jbeIDrxDXW18vBuUxOj+N5msJe/elIJlgI4znfi4 riotpot@riotpot.com" >> /root/.ssh/authorized_keys
+COPY keys/riotpot_ed25519.pub /root/.ssh/authorized_keys
+
+
+# Set up SSH configuration
+RUN mkdir /var/run/sshd
+RUN echo 'root:password' | chpasswd
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Expose SSH port
+EXPOSE 22
+
+# Set SSH as the entry point
+CMD ["/usr/sbin/sshd", "-D"]

--- a/build/docker/service/custom_sshd/README.md
+++ b/build/docker/service/custom_sshd/README.md
@@ -1,0 +1,23 @@
+# Custom SSH Service 
+
+## Security Considerations 
+
+This custom SSH service is designed for testing purposes only and should not be used in a production environment.
+
+1. Password-based authentication for the root user is enabled, which is generally not recommended for security reasons.
+2. Key-based authentication authentication is crucial for securing your SSH service. Below are the steps to generate SSH keys. 
+
+## Generating SSH Keys 
+
+Generate keys in `service/custom_sshd/keys`:
+
+```
+$ ssh-keygen -t rsa -b 4096 -C "riotpot@riotpot.com" -f ./keys/riopot_rsa
+```
+
+or 
+
+```
+$ ssh-keygen -C "riotpot@riotpot.com" -t ed25519 -f ./keys/riotpot_ed25519
+```
+

--- a/build/docker/service/custom_telnet/Dockerfile
+++ b/build/docker/service/custom_telnet/Dockerfile
@@ -1,0 +1,11 @@
+# Use the Ubuntu base image
+FROM ubuntu
+
+# Install Telnet
+RUN apt-get update && apt-get install -y telnet
+
+# Expose port 23 for Telnet
+EXPOSE 23
+
+# Set Telnet as the entry point
+CMD ["telnet", "localhost"]

--- a/test/external/httpd_apache_test.go
+++ b/test/external/httpd_apache_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func removeWhitespace(s string) string {
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "\t", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}
+
+func TestValidPathHandler(t *testing.T) {
+	resp, err := http.Get("http://localhost:80")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Check the response status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the response body
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	// Assert that the response body contains the expected HTML content
+	expectedBody := `<html lang="en">
+	<head>
+		<!-- Page title -->
+		<title>SCADA Login</title>
+
+		<!-- Meta tags -->
+		<meta charset="UTF-8">
+		<meta id="viewport" name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- CSS -->
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" 
+		rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" 
+		crossorigin="anonymous">
+	</head>
+	<body>
+		<h1>Login</h1><br>
+		<div class="container">
+			<form method="POST">
+				<div class="mb-3 row">
+					<label for="username" class="form-label">Username</label>
+					<input id="username" name="username" class="form-control" type="text" placeholder="Username">
+				</div>
+				<div class="mb-3 row">
+					<label for="password" class="form-label">Password</label>
+					<input id="password" name="password" class="form-control" type="password" placeholder="Password">
+				</div>
+				<button type="submit">Log In</button>
+			</form>
+		</div>
+	</body>
+	</html>`
+
+	// Remove newline and tab characters from expectedBody and body
+	expectedBody = removeWhitespace(expectedBody)
+	bodyStr := removeWhitespace(string(body))
+	assert.Equal(t, expectedBody, bodyStr)
+}


### PR DESCRIPTION
Added real-world simulation of a ssh server - installing openssh in a ubuntu image.

For password-based authentication, we set `RUN echo 'root:password' | chpasswd` and below is the testing:
```
ssh root@localhost -p 2222
root@localhost's password: 
Permission denied, please try again.
root@localhost's password: 
Welcome to Ubuntu 22.04.2 LTS (GNU/Linux 5.15.0-78-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.

The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

root@9ad2e536996c:~# 
```


For key-based authentication, I added a README on how to generate the keys. Below is the test:
```
$ ssh -i riotpot_ed25519 root@localhost -p 2222
Welcome to Ubuntu 22.04.2 LTS (GNU/Linux 5.15.0-78-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.

The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

root@200449a06c7f:~# 
````
