### PR TITLE
test: TestApiService fixed and correction in the parse.go 

### DIFF
--- a/cmd/riotpot/parse.go
+++ b/cmd/riotpot/parse.go
@@ -72,7 +72,7 @@ func createApiRouter(whitelist []string, startUi bool) *gin.Engine {
 
 	group := router.Group("/api/")
 	api.ProxiesRouter.AddToGroup(group)
-	api.ServiceRouter.AddToGroup(group)
+	api.ServicesRouter.AddToGroup(group)
 
 	if startUi {
 		ui.AddRoutes(router)

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -65,6 +65,7 @@ func TestApiService(t *testing.T) {
 		Host:    "localhost",
 		Port:    8080,
 		Network: utils.TCP.String(),
+		Interaction: "low",
 	}
 
 	router := SetupRouter()


### PR DESCRIPTION
Fixes #52 

- The failing test case is solved by Adding the Interaction field to the expected .
- And added the api.ServicesRouter in the parse.go.