### PR TITLE
fix compile.sh permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY statik/ statik/
 COPY build build/
 
 ADD Makefile .
+RUN chmod +x build/compile.sh
 RUN make compile
 
 FROM golang:1.21 AS release


### PR DESCRIPTION

This simply fixes this:
```
<snip>
[+] Building 1.6s (18/19)                                                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                                          0.0s
 => => transferring dockerfile: 756B                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/golang:1.21                                                                                                                0.4s
 => [internal] load .dockerignore                                                                                                                                             0.1s
 => => transferring context: 55B                                                                                                                                              0.0s
 => [builder  1/14] FROM docker.io/library/golang:1.21@sha256:4746d26432a9117a5f58e95cb9f954ddf0de128e9d5816886514199316e4a2fb                                                0.0s
 => [internal] load build context                                                                                                                                             0.2s
 => => transferring context: 29.29MB                                                                                                                                          0.2s
<snip>
 => CACHED [builder 13/14] ADD Makefile .                                                                                                                                     0.0s
 => ERROR [builder 14/14] RUN make compile                                                                                                                                    0.6s
------                                                                                                                                                                             
 > [builder 14/14] RUN make compile:                                                                                                                                               
0.286 build/compile.sh                                                                                                                                                             
0.287 bash: line 1: build/compile.sh: Permission denied
0.287 make: *** [Makefile:9: compile] Error 126
------
Dockerfile:28
--------------------
  26 |     
  27 |     ADD Makefile .
  28 | >>> RUN make compile
  29 |     
  30 |     FROM golang:1.21 AS release
--------------------
ERROR: failed to solve: process "/bin/sh -c make compile" did not complete successfully: exit code: 2

```
Docker version 27.3.1, build ce12230
Docker Compose version v2.11.1
Debian12
